### PR TITLE
fix typo np.cov()

### DIFF
--- a/AEPSHEP2022/notebook1.ipynb
+++ b/AEPSHEP2022/notebook1.ipynb
@@ -303,7 +303,7 @@
    "source": [
     "print('sample means:', np.mean(xvals), np.mean(yvals))\n",
     "print('sample variances:', np.var(xvals, ddof=1), np.var(yvals, ddof=1))\n",
-    "print('sample covariance and correlation coefficient:', np.cov(xvals, xvals, ddof=1)[0,1], np.corrcoef(xvals,yvals)[0,1])\n"
+    "print('sample covariance and correlation coefficient:', np.cov(xvals, yvals, ddof=1)[0,1], np.corrcoef(xvals,yvals)[0,1])\n"
    ]
   },
   {


### PR DESCRIPTION
fix typo np.cov(). It computes covariance of xvals against xvals